### PR TITLE
feat: customize cache control

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The original site for eggplants/ghcr-badge is ~~no longer available~~ often stop
 - `n`: Number of tags to display (default: `3`)
 - `label`: Badge label (default: `image tags`)
 - `trim`: Tag trimming option
+- `cache`: Max-age for the badge (default: `3600`)
 
 **Example:**  
 ![Tag Example](https://ghcr-badge.yuchanns.xyz/containerd/nerdctl/tags?ignore=latest)
@@ -71,6 +72,7 @@ https://ghcr-badge.yuchanns.xyz/containerd/nerdctl/tags?ignore=latest
 - `ignore`: Tag to ignore (default: `latest`)
 - `label`: Badge label (default: `version`)
 - `trim`: Tag trimming option
+- `cache`: Max-age for the badge (default: `3600`)
 
 **Example:**  
 ![Latest Tag Example](https://ghcr-badge.yuchanns.xyz/containerd/nerdctl/latest_tag?label=latest)
@@ -88,6 +90,7 @@ https://ghcr-badge.yuchanns.xyz/containerd/nerdctl/latest_tag?label=latest
 - `tag`: Tag to check size for (default: `latest`)
 - `label`: Badge label (default: `image size`)
 - `trim`: Tag trimming option
+- `cache`: Max-age for the badge (default: `3600`)
 
 **Example:**  
 ![Size Example](https://ghcr-badge.yuchanns.xyz/containerd/nerdctl/size)
@@ -101,6 +104,14 @@ https://ghcr-badge.yuchanns.xyz/containerd/nerdctl/size
 ![Container Tags](https://your-worker-url.workers.dev/username/repo/tags)
 ![Latest Version](https://your-worker-url.workers.dev/username/repo/latest_tag)
 ![Image Size](https://your-worker-url.workers.dev/username/repo/size)
+```
+
+## 🔄 Cache Control
+
+Generated badge will be cached for 3600 seconds in GitHub's [Camo](https://github.com/atmos/camo) server. To update immediately, send PURGE request to the badge Camo link.
+
+```bash
+curl -X PURGE "https://camo.githubusercontent.com/..."
 ```
 
 ## 📄 License

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { logger } from "hono/logger"
 import { prettyJSON } from "hono/pretty-json"
 import { Hono } from "hono/tiny"
 import { providers } from "./apis"
-import { bufferMiddleware, loggingMiddleware } from "./middlewares"
+import { bufferMiddleware, cacheControlMiddleware, loggingMiddleware } from "./middlewares"
 import { InvalidError } from "./errors"
 import { getBadge } from "./utils"
 
@@ -33,7 +33,7 @@ const app = new Hono().use(
 )
 
 app
-  .use(bufferMiddleware, loggingMiddleware)
+  .use(bufferMiddleware, loggingMiddleware, cacheControlMiddleware)
 
 Object.entries(providers).forEach(([_, provider]) => {
   app.route("/", provider.route)

--- a/src/middlewares/cache.ts
+++ b/src/middlewares/cache.ts
@@ -1,0 +1,8 @@
+import { Context, Next } from "hono"
+
+export const cacheControlMiddleware = async (c: Context, next: Next) => {
+  const { cache } = c.req.query()
+  const cacheDuration = Math.max(1, parseInt(cache || "3600")) // Default to 1 hour
+  await next()
+  c.res.headers.set("Cache-Control", `public, max-age=${cacheDuration}`)
+}

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -1,3 +1,4 @@
 export * from "./buffer"
 export * from "./logging"
+export * from "./cache"
 


### PR DESCRIPTION
The camo service never expires the badge because no Cache-Control is set, according to https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-anonymized-urls.

This PR fixes that and adds a parameter to customize the max-age of Cache-Control.